### PR TITLE
Add spy-based intel system

### DIFF
--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -134,6 +134,10 @@ export class SendEmbargoIntentEvent implements GameEvent {
   ) {}
 }
 
+export class SendGatherIntelIntentEvent implements GameEvent {
+  constructor(public readonly target: PlayerView) {}
+}
+
 export class CancelAttackIntentEvent implements GameEvent {
   constructor(public readonly attackID: string) {}
 }
@@ -223,6 +227,9 @@ export class Transport {
     this.eventBus.on(SendQuickChatEvent, (e) => this.onSendQuickChatIntent(e));
     this.eventBus.on(SendEmbargoIntentEvent, (e) =>
       this.onSendEmbargoIntent(e),
+    );
+    this.eventBus.on(SendGatherIntelIntentEvent, (e) =>
+      this.onSendGatherIntelIntent(e),
     );
     this.eventBus.on(SendSetTargetTroopRatioEvent, (e) =>
       this.onSendSetTargetTroopRatioEvent(e),
@@ -521,6 +528,14 @@ export class Transport {
       clientID: this.lobbyConfig.clientID,
       targetID: event.target.id(),
       action: event.action,
+    });
+  }
+
+  private onSendGatherIntelIntent(event: SendGatherIntelIntentEvent) {
+    this.sendIntent({
+      type: "gather_intel",
+      clientID: this.lobbyConfig.clientID,
+      target: event.target.id(),
     });
   }
 

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -37,6 +37,7 @@ export type Intent =
   | DonateTroopsIntent
   | TargetTroopRatioIntent
   | BuildUnitIntent
+  | GatherDefenseIntelIntent
   | EmbargoIntent
   | QuickChatIntent
   | MoveWarshipIntent
@@ -61,6 +62,9 @@ export type TargetTroopRatioIntent = z.infer<
   typeof TargetTroopRatioIntentSchema
 >;
 export type BuildUnitIntent = z.infer<typeof BuildUnitIntentSchema>;
+export type GatherDefenseIntelIntent = z.infer<
+  typeof GatherDefenseIntelIntentSchema
+>;
 export type UpgradeStructureIntent = z.infer<
   typeof UpgradeStructureIntentSchema
 >;
@@ -324,6 +328,11 @@ export const BuildUnitIntentSchema = BaseIntentSchema.extend({
   y: z.number(),
 });
 
+export const GatherDefenseIntelIntentSchema = BaseIntentSchema.extend({
+  type: z.literal("gather_intel"),
+  target: ID,
+});
+
 export const UpgradeStructureIntentSchema = BaseIntentSchema.extend({
   type: z.literal("upgrade_structure"),
   unit: z.enum(UnitType),
@@ -374,6 +383,7 @@ const IntentSchema = z.discriminatedUnion("type", [
   DonateTroopIntentSchema,
   TargetTroopRatioIntentSchema,
   BuildUnitIntentSchema,
+  GatherDefenseIntelIntentSchema,
   UpgradeStructureIntentSchema,
   EmbargoIntentSchema,
   MoveWarshipIntentSchema,

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -534,6 +534,16 @@ export class DefaultConfig implements Config {
           territoryBound: false,
           experimental: true,
         };
+      case UnitType.Spy:
+        return {
+          cost: () => 100000n,
+          territoryBound: false,
+        };
+      case UnitType.Satellite:
+        return {
+          cost: () => 500000n,
+          territoryBound: false,
+        };
       default:
         assertNever(type);
     }

--- a/src/core/execution/ExecutionManager.ts
+++ b/src/core/execution/ExecutionManager.ts
@@ -15,6 +15,7 @@ import { DonateTroopsExecution } from "./DonateTroopExecution";
 import { EmbargoExecution } from "./EmbargoExecution";
 import { EmojiExecution } from "./EmojiExecution";
 import { FakeHumanExecution } from "./FakeHumanExecution";
+import { GatherDefenseIntelExecution } from "./intel/GatherDefenseIntelExecution";
 import { MarkDisconnectedExecution } from "./MarkDisconnectedExecution";
 import { MoveWarshipExecution } from "./MoveWarshipExecution";
 import { NoOpExecution } from "./NoOpExecution";
@@ -111,6 +112,8 @@ export class Executor {
           intent.unit,
           new Cell(intent.x, intent.y),
         );
+      case "gather_intel":
+        return new GatherDefenseIntelExecution(player, intent.target);
       case "allianceExtension": {
         return new AllianceExtensionExecution(player, intent.recipient);
       }

--- a/src/core/execution/intel/GatherDefenseIntelExecution.ts
+++ b/src/core/execution/intel/GatherDefenseIntelExecution.ts
@@ -1,0 +1,46 @@
+import { Execution, Game, Player, PlayerID, UnitType } from "../../game/Game";
+
+export class GatherDefenseIntelExecution implements Execution {
+  private target: Player | null = null;
+  private active = true;
+
+  constructor(
+    private requestor: Player,
+    private targetID: PlayerID,
+  ) {}
+
+  init(mg: Game): void {
+    if (!mg.hasPlayer(this.targetID)) {
+      console.warn(
+        `GatherDefenseIntelExecution target ${this.targetID} not found`,
+      );
+      this.active = false;
+      return;
+    }
+    this.target = mg.player(this.targetID);
+  }
+
+  tick(): void {
+    if (this.target === null) {
+      throw new Error("GatherDefenseIntelExecution not initialized");
+    }
+    const spies =
+      this.requestor.unitCount(UnitType.Spy) +
+      this.requestor.unitCount(UnitType.Satellite);
+    if (spies === 0) {
+      console.warn("no intel units available");
+      this.active = false;
+      return;
+    }
+    this.requestor.gatherDefenseIntel(this.target);
+    this.active = false;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+}

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -8,6 +8,7 @@ import {
   UnitUpdate,
 } from "./GameUpdates";
 import { PlayerView } from "./GameView";
+import { IntelReport } from "./Intel";
 import { RailNetwork } from "./RailNetwork";
 import { Stats } from "./Stats";
 
@@ -160,6 +161,8 @@ export enum UnitType {
   Construction = "Construction",
   Train = "Train",
   Factory = "Factory",
+  Spy = "Spy",
+  Satellite = "Satellite",
 }
 
 export enum TrainType {
@@ -236,6 +239,10 @@ export interface UnitParamsMap {
   };
 
   [UnitType.Construction]: Record<string, never>;
+
+  [UnitType.Spy]: Record<string, never>;
+
+  [UnitType.Satellite]: Record<string, never>;
 }
 
 // Type helper to get params type for a specific unit type
@@ -610,6 +617,9 @@ export interface Player {
   tradingPorts(port: Unit): Unit[];
   // WARNING: this operation is expensive.
   bestTransportShipSpawn(tile: TileRef): TileRef | false;
+
+  gatherDefenseIntel(target: Player): IntelReport;
+  intelOn(target: Player): IntelReport | undefined;
 }
 
 export interface Game extends GameMap {
@@ -649,6 +659,8 @@ export interface Game extends GameMap {
   units(...types: UnitType[]): Unit[];
   unitCount(type: UnitType): number;
   unitInfo(type: UnitType): UnitInfo;
+
+  defenseIntel(target: Player): IntelReport;
   hasUnitNearby(
     tile: TileRef,
     searchRange: number,

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -32,6 +32,7 @@ import {
 } from "./Game";
 import { GameMap, TileRef, TileUpdate } from "./GameMap";
 import { GameUpdate, GameUpdateType } from "./GameUpdates";
+import { IntelAsset, IntelReport } from "./Intel";
 import { PlayerImpl } from "./PlayerImpl";
 import { RailNetwork } from "./RailNetwork";
 import { createRailNetwork } from "./RailNetworkImpl";
@@ -220,6 +221,19 @@ export class GameImpl implements Game {
 
   unitInfo(type: UnitType): UnitInfo {
     return this.config().unitInfo(type);
+  }
+
+  defenseIntel(target: Player): IntelReport {
+    const defenseUnits = target.units(
+      UnitType.DefensePost,
+      UnitType.SAMLauncher,
+      UnitType.MissileSilo,
+    );
+    const assets: IntelAsset[] = defenseUnits.map((u) => ({
+      tile: u.tile(),
+      type: u.type(),
+    }));
+    return { target: target.id(), assets };
   }
 
   nations(): Nation[] {

--- a/src/core/game/Intel.ts
+++ b/src/core/game/Intel.ts
@@ -1,4 +1,5 @@
-import { TileRef, UnitType } from "./Game";
+import { UnitType } from "./Game";
+import { TileRef } from "./GameMap";
 
 export interface IntelAsset {
   tile: TileRef;

--- a/src/core/game/Intel.ts
+++ b/src/core/game/Intel.ts
@@ -1,0 +1,11 @@
+import { TileRef, UnitType } from "./Game";
+
+export interface IntelAsset {
+  tile: TileRef;
+  type: UnitType;
+}
+
+export interface IntelReport {
+  target: string;
+  assets: IntelAsset[];
+}

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -48,6 +48,7 @@ import {
   GameUpdateType,
   PlayerUpdate,
 } from "./GameUpdates";
+import { IntelReport } from "./Intel";
 import {
   bestShoreDeploymentSource,
   canBuildTransportShip,
@@ -100,6 +101,8 @@ export class PlayerImpl implements Player {
 
   private relations = new Map<Player, number>();
 
+  private intelReports = new Map<PlayerID, IntelReport>();
+
   public _incomingAttacks: Attack[] = [];
   public _outgoingAttacks: Attack[] = [];
   public _outgoingLandAttacks: Attack[] = [];
@@ -121,6 +124,16 @@ export class PlayerImpl implements Player {
     this._gold = 0n;
     this._displayName = this._name; // processName(this._name)
     this._pseudo_random = new PseudoRandom(simpleHash(this.playerInfo.id));
+  }
+
+  gatherDefenseIntel(target: Player): IntelReport {
+    const report = this.mg.defenseIntel(target);
+    this.intelReports.set(target.id(), report);
+    return report;
+  }
+
+  intelOn(target: Player): IntelReport | undefined {
+    return this.intelReports.get(target.id());
   }
 
   largestClusterBoundingBox: { min: Cell; max: Cell } | null;
@@ -906,6 +919,9 @@ export class PlayerImpl implements Player {
       case UnitType.TradeShip:
         return this.tradeShipSpawn(targetTile);
       case UnitType.Train:
+        return this.landBasedUnitSpawn(targetTile);
+      case UnitType.Spy:
+      case UnitType.Satellite:
         return this.landBasedUnitSpawn(targetTile);
       case UnitType.MissileSilo:
       case UnitType.DefensePost:

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -127,6 +127,11 @@ export class PlayerImpl implements Player {
   }
 
   gatherDefenseIntel(target: Player): IntelReport {
+    const numIntelUnits =
+      this.unitCount(UnitType.Spy) + this.unitCount(UnitType.Satellite);
+    if (numIntelUnits === 0) {
+      throw new Error("No intel units available");
+    }
     const report = this.mg.defenseIntel(target);
     this.intelReports.set(target.id(), report);
     return report;

--- a/tests/IntelSystem.test.ts
+++ b/tests/IntelSystem.test.ts
@@ -1,0 +1,31 @@
+import {
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+  UnitType,
+} from "../src/core/game/Game";
+import { setup } from "./util/Setup";
+
+let game: Game;
+let spyPlayer: Player;
+let target: Player;
+
+beforeEach(async () => {
+  game = await setup("plains", { infiniteGold: true, instantBuild: true }, [
+    new PlayerInfo("spy", PlayerType.Human, null, "spy"),
+    new PlayerInfo("target", PlayerType.Human, null, "target"),
+  ]);
+  while (game.inSpawnPhase()) {
+    game.executeNextTick();
+  }
+  spyPlayer = game.player("spy");
+  target = game.player("target");
+});
+
+test("gatherDefenseIntel reveals defenses", () => {
+  target.buildUnit(UnitType.DefensePost, game.ref(1, 1), {});
+  const report = spyPlayer.gatherDefenseIntel(target);
+  expect(report.assets.length).toBe(1);
+  expect(report.assets[0].type).toBe(UnitType.DefensePost);
+});

--- a/tests/IntelSystem.test.ts
+++ b/tests/IntelSystem.test.ts
@@ -1,3 +1,4 @@
+import { GatherDefenseIntelExecution } from "../src/core/execution/intel/GatherDefenseIntelExecution";
 import {
   Game,
   Player,
@@ -25,7 +26,11 @@ beforeEach(async () => {
 
 test("gatherDefenseIntel reveals defenses", () => {
   target.buildUnit(UnitType.DefensePost, game.ref(1, 1), {});
-  const report = spyPlayer.gatherDefenseIntel(target);
+  spyPlayer.buildUnit(UnitType.Spy, game.ref(0, 0), {});
+  game.addExecution(new GatherDefenseIntelExecution(spyPlayer, target.id()));
+  game.executeNextTick();
+  game.executeNextTick();
+  const report = spyPlayer.intelOn(target)!;
   expect(report.assets.length).toBe(1);
   expect(report.assets[0].type).toBe(UnitType.DefensePost);
 });


### PR DESCRIPTION
## Summary
- add Spy and Satellite units
- implement intel reports and gathering
- expose defense intel APIs
- provide default costs for new units
- cover with IntelSystem test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687854e6c9dc832f9b6d01354406a840